### PR TITLE
Removed "Notice: Undefined variable $user on line 182"

### DIFF
--- a/votingstar.php
+++ b/votingstar.php
@@ -179,7 +179,7 @@ function votingstar_handle_input() {
 	if ( 'csv' === $vs ) {
 		header( 'Content-Disposition: inline; filename="votes.csv"' );
 		header( 'Content-type: text/plain' );
-		$data = votingstar_votes( $user );
+		$data = votingstar_votes();
 		foreach ( $data->votes as $k => $v ) {
 			echo "$k\t$v\n";
 		}


### PR DESCRIPTION
The transfer of the undefined parameter / variable $ user resulted in the notice XY. By omitting the transfer of a parameter, the default value defined in the function "zero" (which has already been used before), but the notice no longer appears.